### PR TITLE
Make link not taking whole space

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -49,7 +49,7 @@ const About = () => {
           learning new technologies.
         </p>
         <Link href="/#projects">
-          <p className="py-2 text-gray-600 underline cursor-pointer">
+          <p className="py-2 text-gray-600 inline underline cursor-pointer">
             Check out some of my latest projects.
           </p>
         </Link>


### PR DESCRIPTION
By using `inline` class from Tailwind, I think it might solve the issue of the link taking up the whole space. However, you can use `display: inline` in CSS to achieve the same as well.